### PR TITLE
Move poles instead of their meshes

### DIFF
--- a/apps/3d/src/pole.ts
+++ b/apps/3d/src/pole.ts
@@ -1,5 +1,4 @@
 import * as THREE from "three";
-import { Lashing } from "./lashing";
 
 export class Pole extends THREE.Object3D {
   mesh: THREE.Mesh;
@@ -48,6 +47,7 @@ export class Pole extends THREE.Object3D {
     }); // Blue color
     this.capTop = new THREE.Mesh(capGeometry, capMaterial);
     this.capBottom = new THREE.Mesh(capGeometry, capMaterial);
+    this.setPositionCaps();
 
     // Add top and bottom caps to the pole
     this.add(this.capTop);
@@ -64,7 +64,6 @@ export class Pole extends THREE.Object3D {
     );
     this.name = pole.name;
     this.setLength(pole.length);
-    this.setPositionMesh(pole.mesh.x, pole.mesh.y, pole.mesh.z);
     this.rotation.set(pole.rotation._x, pole.rotation._y, pole.rotation._z);
     this.uuid = pole.uuid;
   }
@@ -89,8 +88,7 @@ export class Pole extends THREE.Object3D {
   }
 
   setPositionOnGround(position: THREE.Vector3) {
-    this.position.set(position.x, position.y, position.z);
-    this.setPositionMesh(0, 2, 0);
+    this.position.set(position.x, position.y + this.length / 2.0, position.z);
     this.setDirection(new THREE.Vector3(0, 1, 0));
   }
 
@@ -98,12 +96,14 @@ export class Pole extends THREE.Object3D {
     groundPoint: THREE.Vector3,
     polePoint: THREE.Vector3
   ) {
-    this.position.set(groundPoint.x, groundPoint.y, groundPoint.z);
     const targetOrientationVector = polePoint.clone().sub(groundPoint.clone());
     const distance = targetOrientationVector.length();
     this.setLength(distance + 0.15);
     this.setDirection(targetOrientationVector);
-    this.setPositionMesh(0, this.length / 2.0, 0);
+    const targetPosition = groundPoint
+      .clone()
+      .add(this.direction.clone().multiplyScalar(this.length / 2.0));
+    this.position.set(targetPosition.x, targetPosition.y, targetPosition.z);
   }
 
   setPositionBetweenTwoPoles(pointA: THREE.Vector3, pointB: THREE.Vector3) {
@@ -112,7 +112,6 @@ export class Pole extends THREE.Object3D {
     const targetOrientationVector = pointB.clone().sub(pointA.clone());
     const distance = targetOrientationVector.length();
     this.setLength(distance + 0.3);
-    this.setPositionMesh(0, 0, 0);
     this.setDirection(targetOrientationVector);
   }
 
@@ -153,20 +152,14 @@ export class Pole extends THREE.Object3D {
       transparent: true,
       opacity: 0.5,
     });
+    this.setPositionCaps();
   }
 
-  setPositionMesh(x: number, y: number, z: number) {
-    this.mesh.position.set(x, y, z);
-    this.capBottom.position.set(
-      x,
-      y - (this.length - this.capLength) / 2 - this.capOffset,
-      z
-    );
-    this.capTop.position.set(
-      x,
-      y + (this.length - this.capLength) / 2 + this.capOffset,
-      z
-    );
+  setPositionCaps() {
+    (this.capBottom.position.y =
+      -(this.length - this.capLength) / 2 - this.capOffset),
+      (this.capTop.position.y =
+        (this.length - this.capLength) / 2 + this.capOffset);
   }
 
   select() {

--- a/apps/3d/src/poleTool.ts
+++ b/apps/3d/src/poleTool.ts
@@ -34,19 +34,17 @@ export class PoleTool {
     this.viewer.scene.add(demoPole1);
     this.viewer.poles.push(demoPole1);
     demoPole1.position.x = -0.07;
-    demoPole1.position.y = 0;
-    demoPole1.position.z = -0.8;
-    demoPole1.setPositionMesh(0, 2, 0);
+    demoPole1.position.y = 1.74;
+    demoPole1.position.z = 0.1;
     demoPole1.setDirection(new THREE.Vector3(0, 1.8, 1));
     demoPole1.name = "demoPole1";
 
     const demoPole2 = new Pole();
     this.viewer.scene.add(demoPole2);
     this.viewer.poles.push(demoPole2);
-    demoPole2.position.x = 1.8;
-    demoPole2.position.y = 0;
+    demoPole2.position.x = 0.9;
+    demoPole2.position.y = 1.74;
     demoPole2.position.z = 0.93;
-    demoPole2.setPositionMesh(0, 2, 0);
     demoPole2.setDirection(new THREE.Vector3(-1, 1.8, 0));
     demoPole2.name = "demoPole2";
 
@@ -54,19 +52,17 @@ export class PoleTool {
     this.viewer.scene.add(demoPole3);
     this.viewer.poles.push(demoPole3);
     demoPole3.position.x = 0.07;
-    demoPole3.position.y = 0;
-    demoPole3.position.z = 2.8;
-    demoPole3.setPositionMesh(0, 2, 0);
+    demoPole3.position.y = 1.74;
+    demoPole3.position.z = 1.9;
     demoPole3.setDirection(new THREE.Vector3(0, 1.8, -1));
     demoPole3.name = "demoPole3";
 
     const demoPole4 = new Pole();
     this.viewer.scene.add(demoPole4);
     this.viewer.poles.push(demoPole4);
-    demoPole4.position.x = -1.8;
-    demoPole4.position.y = 0;
+    demoPole4.position.x = -0.9;
+    demoPole4.position.y = 1.74;
     demoPole4.position.z = 1.07;
-    demoPole4.setPositionMesh(0, 2, 0);
     demoPole4.setDirection(new THREE.Vector3(1, 1.8, 0));
     demoPole4.name = "demoPole4";
   }
@@ -167,7 +163,6 @@ export class PoleTool {
       this.newLashing.centerLoosePole.y,
       this.newLashing.centerLoosePole.z
     );
-    this.activePole.setPositionMesh(0, 0, 0);
   }
 
   placePoleBetweenOneLashingAndGround(groundPosition: THREE.Vector3) {


### PR DESCRIPTION
From now on the position of a pole should always be in it's center, so the coordinates of the mesh are always 

0, 0, 0 

and the caps 

0, +- poleLength / 2, 0