### PR TITLE
Improve scaffold rendering

### DIFF
--- a/apps/3d/src/poleTransformer.ts
+++ b/apps/3d/src/poleTransformer.ts
@@ -41,6 +41,8 @@ export class PoleTransformer extends THREE.Object3D {
   }
 
   setActivePole(pole: Pole | undefined) {
+    if (this.activeScaffold && !this.activeScaffold.extensionPole.visible)
+      this.activeScaffold.removeExtensionFromScene(this.viewer.scene);
     if (pole) {
       this.activeScaffold = new Scaffold();
       this.activeScaffold.setMainPole(pole);
@@ -162,6 +164,9 @@ export class PoleTransformer extends THREE.Object3D {
   }
 
   dropScaleHandle() {
+    if (!this.activeScaffold.extensionPole.visible) {
+      this.activeScaffold.removeExtensionFromScene(this.viewer.scene);
+    }
     this.activeScaffold.addExtensionToViewer(this.viewer);
   }
 }

--- a/apps/3d/src/scaffold.ts
+++ b/apps/3d/src/scaffold.ts
@@ -241,6 +241,12 @@ export class Scaffold {
     }
   }
 
+  removeExtensionFromScene(scene: THREE.Scene) {
+    for (const pole of [this.extensionPole, this.splintPole]) {
+      scene.remove(pole);
+    }
+  }
+
   addToViewer(viewer: Viewer) {
     for (const pole of [this.mainPole, this.extensionPole, this.splintPole]) {
       if (pole.visible) {


### PR DESCRIPTION
Scaffolds no longer render in black for a split second.

Scaffolds contain at most 1 extension and one splint pole.