### PR TITLE
Scaffold lashings

### DIFF
--- a/src/inputHandler.ts
+++ b/src/inputHandler.ts
@@ -130,6 +130,7 @@ export class InputHandler {
       ...this.viewer.inventory.poles.map((pole) => pole.mesh),
       ...this.viewer.inventory.lashings.map((lashing) => lashing.mesh),
       ...this.viewer.inventory.bipodLashings.map((lashing) => lashing.mesh),
+      ...this.viewer.inventory.scaffoldLashings.map((lashing) => lashing.mesh),
     ]);
 
     if (intersects.length) {

--- a/src/objects/lashings/scaffoldLashing.ts
+++ b/src/objects/lashings/scaffoldLashing.ts
@@ -1,0 +1,96 @@
+import * as THREE from "three";
+import { Pole } from "../pole";
+import { Scaffold } from "../scaffold";
+import { v4 as uuidv4 } from "uuid";
+import { ScaffoldLashingCurve } from "./scaffoldLashingCurve";
+
+export class ScaffoldLashing extends THREE.Object3D {
+  identifier: string;
+  pole1: Pole;
+  pole2: Pole;
+  centerPole1: THREE.Vector3;
+  centerPole2: THREE.Vector3;
+  offset: number;
+
+  mesh: THREE.Mesh;
+  constructor(pole1: Pole, pole2: Pole, offset: number, identifier?: string) {
+    super();
+    this.identifier = identifier || uuidv4();
+    this.offset = offset;
+    this.pole1 = pole1;
+    this.pole2 = pole2;
+
+    this.mesh = new THREE.Mesh();
+    this.mesh.material = new THREE.MeshStandardMaterial({
+      color: 0x9e9578,
+      wireframe: false,
+    });
+    this.add(this.mesh);
+
+    this.update();
+  }
+
+  setOffset(offset: number) {
+    this.offset = offset;
+    this.update();
+  }
+
+  update() {
+    this.centerPole1 = this.pole1.position
+      .clone()
+      .add(this.pole1.direction.clone().multiplyScalar(this.offset));
+    const perpendicularVector = new THREE.Vector3().crossVectors(
+      this.pole1.direction,
+      this.pole1.position.clone().sub(this.pole2.position)
+    );
+    const connectingVector = new THREE.Vector3()
+      .crossVectors(perpendicularVector, this.pole1.direction)
+      .normalize();
+    this.centerPole2 = this.centerPole1
+      .clone()
+      .add(
+        connectingVector
+          .clone()
+          .multiplyScalar(this.pole1.radius + this.pole2.radius)
+      );
+    this.position.set(
+      this.centerPole1.x,
+      this.centerPole1.y,
+      this.centerPole1.z
+    );
+
+    const path = new ScaffoldLashingCurve(
+      this.pole1.direction,
+      this.centerPole1.clone().sub(this.centerPole2)
+    );
+    this.mesh.geometry.dispose();
+    this.mesh.geometry = new THREE.TubeGeometry(path, 360, 0.003, 8, true);
+  }
+
+  threatenWithDestruction() {
+    // @ts-ignore
+    this.mesh.material.color = new THREE.Color(0x996209);
+  }
+
+  stopThreatening() {
+    // @ts-ignore
+    this.mesh.material.color = new THREE.Color(0x9e9578);
+  }
+
+  relashToRightScaffoldPole(scaffold: Scaffold) {
+    if (scaffold.length < 6.0) return;
+    const distanceToExtension = this.position.distanceTo(
+      scaffold.extensionPole.position
+    );
+    const distanceToMain = this.position.distanceTo(scaffold.mainPole.position);
+    if (distanceToExtension < distanceToMain) {
+      if (this.pole1 === scaffold.mainPole) {
+        this.pole1 = scaffold.extensionPole;
+      } else if (this.pole2 === scaffold.mainPole) {
+        this.pole2 = scaffold.extensionPole;
+      } else {
+        console.error(this.relashToRightScaffoldPole.name);
+      }
+    }
+  }
+}

--- a/src/objects/lashings/scaffoldLashingCurve.ts
+++ b/src/objects/lashings/scaffoldLashingCurve.ts
@@ -1,0 +1,52 @@
+import * as THREE from "three";
+
+export class ScaffoldLashingCurve extends THREE.Curve<THREE.Vector3> {
+  longitudalDirection: THREE.Vector3;
+  radialDirection: THREE.Vector3;
+  tangentialDirection: THREE.Vector3;
+  vP1P2: THREE.Vector3;
+
+  constructor(direction: THREE.Vector3, vP1P2: THREE.Vector3) {
+    super();
+    this.longitudalDirection = direction;
+    this.vP1P2 = vP1P2;
+
+    this.radialDirection = vP1P2.clone().normalize();
+    this.tangentialDirection = new THREE.Vector3()
+      .crossVectors(this.longitudalDirection, this.radialDirection)
+      .normalize();
+  }
+
+  getPoint(t: number, optionalTarget = new THREE.Vector3()) {
+    const strandOffsets = [
+      -4, -3, -2, -1, 0, 1, 2, 3, 4, 4, 3, 2, 1, 0, -1, -2, -3, -4,
+    ];
+    const parts = strandOffsets.length;
+    const rp1 = 0.06; // Radius pole1
+    const rp2 = 0.06; // Radius pole2
+    const ropeDiameter = 0.006;
+    const spacing = ropeDiameter;
+    const pole1Strand = Math.ceil(t * parts) % 2 === 0;
+
+    const x = parts * t * Math.PI;
+    const tx = Math.cos(x);
+    const ty = Math.sin(x);
+    let tz =
+      strandOffsets[Math.min(Math.floor(t * parts), parts - 1)] * spacing;
+
+    if (pole1Strand) {
+      const v = new THREE.Vector3()
+        .add(this.longitudalDirection.clone().multiplyScalar(tz))
+        .add(this.radialDirection.clone().multiplyScalar(ty * rp1))
+        .add(this.tangentialDirection.clone().multiplyScalar(tx * rp1));
+      return optionalTarget.set(v.x, v.y, v.z);
+    } else {
+      const v = new THREE.Vector3()
+        .add(this.longitudalDirection.clone().multiplyScalar(tz))
+        .add(this.radialDirection.clone().multiplyScalar(ty * rp2))
+        .add(this.tangentialDirection.clone().multiplyScalar(tx * rp2))
+        .add(this.vP1P2);
+      return optionalTarget.set(v.x, v.y, v.z);
+    }
+  }
+}

--- a/src/objects/scaffold.ts
+++ b/src/objects/scaffold.ts
@@ -299,6 +299,10 @@ export class Scaffold {
     return [this.extensionPole, this.splintPole].filter((pole) => pole.visible);
   }
 
+  getVisibleScaffoldLashings() {
+    return this.scaffoldLashings.filter((lashing) => lashing.visible);
+  }
+
   setVisible() {
     if (this.length > 6.0) {
       this.mainPole.visible = true;

--- a/src/objects/scaffold.ts
+++ b/src/objects/scaffold.ts
@@ -1,11 +1,13 @@
 import * as THREE from "three";
 import { Pole } from "../objects/pole";
-import { Viewer } from "./../viewer";
+import { ScaffoldLashing } from "./lashings/scaffoldLashing";
 
 export class Scaffold {
   mainPole: Pole;
   extensionPole: Pole;
   splintPole: Pole;
+
+  scaffoldLashings: ScaffoldLashing[];
 
   length: number = 0.0;
   mainRadius: number = 0.0;
@@ -16,12 +18,20 @@ export class Scaffold {
     this.mainRadius = this.mainPole.radius;
     this.splintPole = new Pole();
     this.extensionPole = new Pole();
+    this.scaffoldLashings = [
+      new ScaffoldLashing(this.splintPole, this.mainPole, -1.5),
+      new ScaffoldLashing(this.splintPole, this.mainPole, -0.5),
+      new ScaffoldLashing(this.splintPole, this.extensionPole, 0.5),
+      new ScaffoldLashing(this.splintPole, this.extensionPole, 1.5),
+    ];
   }
 
   setMainPole(pole: Pole) {
     this.mainPole = pole;
     this.length = pole.length;
     this.direction = pole.direction;
+    this.scaffoldLashings[0].pole2 = this.mainPole;
+    this.scaffoldLashings[1].pole2 = this.mainPole;
   }
 
   reset() {
@@ -114,6 +124,9 @@ export class Scaffold {
     this.mainPole.setLength(this.length);
     this.extensionPole.visible = false;
     this.splintPole.visible = false;
+    for (const lashing of this.scaffoldLashings) {
+      lashing.visible = false;
+    }
   }
 
   changeLengthTo8() {
@@ -122,6 +135,10 @@ export class Scaffold {
     this.splintPole.setLength(4.0);
     this.extensionPole.visible = true;
     this.splintPole.visible = true;
+    for (const lashing of this.scaffoldLashings) {
+      lashing.visible = true;
+    }
+    this.setScaffoldLashingPositions();
   }
 
   changeLengthTo10() {
@@ -130,6 +147,10 @@ export class Scaffold {
     this.splintPole.setLength(4.0);
     this.extensionPole.visible = true;
     this.splintPole.visible = true;
+    for (const lashing of this.scaffoldLashings) {
+      lashing.visible = true;
+    }
+    this.setScaffoldLashingPositions();
   }
 
   changeLengthTo12() {
@@ -138,6 +159,17 @@ export class Scaffold {
     this.splintPole.setLength(4.0);
     this.extensionPole.visible = true;
     this.splintPole.visible = true;
+    for (const lashing of this.scaffoldLashings) {
+      lashing.visible = true;
+    }
+    this.setScaffoldLashingPositions();
+  }
+
+  setScaffoldLashingPositions() {
+    this.scaffoldLashings[0].setOffset(0.15 - this.splintPole.length / 2.0);
+    this.scaffoldLashings[1].setOffset(-0.15);
+    this.scaffoldLashings[2].setOffset(0.15);
+    this.scaffoldLashings[3].setOffset(this.splintPole.length / 2.0 - 0.15);
   }
 
   setPositions(position: THREE.Vector3) {
@@ -179,6 +211,9 @@ export class Scaffold {
         offsetPosition.y,
         offsetPosition.z
       );
+    }
+    for (const lashing of this.scaffoldLashings) {
+      lashing.update();
     }
   }
 
@@ -226,6 +261,7 @@ export class Scaffold {
     for (const pole of [this.mainPole, this.extensionPole, this.splintPole]) {
       scene.add(pole);
     }
+    scene.add(...this.scaffoldLashings);
   }
 
   addExtensionToScene(scene: THREE.Scene) {
@@ -233,18 +269,24 @@ export class Scaffold {
       scene.add(pole);
       pole.visible = false;
     }
+    scene.add(...this.scaffoldLashings);
+    for (const lashing of this.scaffoldLashings) {
+      lashing.visible = false;
+    }
   }
 
   removeFromScene(scene: THREE.Scene) {
     for (const pole of [this.mainPole, this.extensionPole, this.splintPole]) {
       scene.remove(pole);
     }
+    scene.remove(...this.scaffoldLashings);
   }
 
   removeExtensionFromScene(scene: THREE.Scene) {
     for (const pole of [this.extensionPole, this.splintPole]) {
       scene.remove(pole);
     }
+    scene.remove(...this.scaffoldLashings);
   }
 
   getVisiblePoles() {
@@ -262,10 +304,16 @@ export class Scaffold {
       this.mainPole.visible = true;
       this.extensionPole.visible = true;
       this.splintPole.visible = true;
+      for (const lashing of this.scaffoldLashings) {
+        lashing.visible = true;
+      }
     } else {
       this.mainPole.visible = true;
       this.extensionPole.visible = false;
       this.splintPole.visible = false;
+      for (const lashing of this.scaffoldLashings) {
+        lashing.visible = false;
+      }
     }
   }
 
@@ -273,5 +321,8 @@ export class Scaffold {
     this.mainPole.visible = false;
     this.extensionPole.visible = false;
     this.splintPole.visible = false;
+    for (const lashing of this.scaffoldLashings) {
+      lashing.visible = false;
+    }
   }
 }

--- a/src/tools/bipodTool.ts
+++ b/src/tools/bipodTool.ts
@@ -88,6 +88,11 @@ export class BipodTool extends Tool {
         ...this.scaffold2.getVisiblePoles(),
       ];
       this.viewer.inventory.addPoles(polesToAdd);
+      const scaffoldLashingsToAdd = [
+        ...this.scaffold1.getVisibleScaffoldLashings(),
+        ...this.scaffold2.getVisibleScaffoldLashings(),
+      ];
+      this.viewer.inventory.addScaffoldLashings(scaffoldLashingsToAdd);
       this.scaffold1 = new Scaffold();
       this.scaffold2 = new Scaffold();
       this.scaffold1.addToScene(this.viewer.scene);

--- a/src/tools/destructionTool.ts
+++ b/src/tools/destructionTool.ts
@@ -1,5 +1,6 @@
 import { BipodLashing } from "../objects/lashings/bipodLashing";
 import { Lashing } from "../objects/lashings/lashing";
+import { ScaffoldLashing } from "../objects/lashings/scaffoldLashing";
 import { Pole } from "../objects/pole";
 import { Viewer } from "../viewer";
 import { Tool } from "./tool";
@@ -7,7 +8,7 @@ import { Tool } from "./tool";
 export class DestructionTool extends Tool {
   active: boolean;
   viewer: Viewer;
-  hoveredObject: Pole | Lashing | BipodLashing | undefined;
+  hoveredObject: Pole | Lashing | BipodLashing | ScaffoldLashing | undefined;
   constructor(viewer: Viewer) {
     super(viewer);
   }
@@ -29,6 +30,8 @@ export class DestructionTool extends Tool {
       this.viewer.inventory.removePoles([this.hoveredObject]);
     } else if (this.hoveredObject instanceof BipodLashing) {
       this.viewer.inventory.removeBipodLashings([this.hoveredObject]);
+    } else if (this.hoveredObject instanceof ScaffoldLashing) {
+      this.viewer.inventory.removeScaffoldLashings([this.hoveredObject]);
     }
   }
 
@@ -37,7 +40,7 @@ export class DestructionTool extends Tool {
     this.setHoveredObject(hoveredObject);
   }
 
-  setHoveredObject(object: Pole | Lashing | BipodLashing) {
+  setHoveredObject(object: Pole | Lashing | BipodLashing | ScaffoldLashing) {
     if (object === this.hoveredObject) return;
     this.hoveredObject?.stopThreatening();
     this.hoveredObject = object;

--- a/src/tools/poleTool.ts
+++ b/src/tools/poleTool.ts
@@ -250,6 +250,12 @@ export class PoleTool extends Tool {
     }
     this.fixedLashing = undefined;
     this.newLashing = undefined;
+
+    if (this.activeScaffold.extensionPole.visible) {
+      this.viewer.inventory.addScaffoldLashings(
+        this.activeScaffold.scaffoldLashings
+      );
+    }
   }
 
   onRightClick() {

--- a/src/tools/poleTool.ts
+++ b/src/tools/poleTool.ts
@@ -251,11 +251,9 @@ export class PoleTool extends Tool {
     this.fixedLashing = undefined;
     this.newLashing = undefined;
 
-    if (this.activeScaffold.extensionPole.visible) {
-      this.viewer.inventory.addScaffoldLashings(
-        this.activeScaffold.scaffoldLashings
-      );
-    }
+    this.viewer.inventory.addScaffoldLashings(
+      this.activeScaffold.getVisibleScaffoldLashings()
+    );
   }
 
   onRightClick() {

--- a/src/tools/poleTransformer.ts
+++ b/src/tools/poleTransformer.ts
@@ -4,8 +4,9 @@ import { Viewer } from "../viewer";
 import { Scaffold } from "../objects/scaffold";
 import { Lashing } from "../objects/lashings/lashing";
 import { BipodLashing } from "../objects/lashings/bipodLashing";
+import { ScaffoldLashing } from "../objects/lashings/scaffoldLashing";
 
-type AnyLashing = Lashing | BipodLashing;
+type AnyLashing = Lashing | BipodLashing | ScaffoldLashing;
 
 export class PoleTransformer extends THREE.Object3D {
   viewer: Viewer;
@@ -91,6 +92,11 @@ export class PoleTransformer extends THREE.Object3D {
           lashing.loosePole === this.activeScaffold.mainPole
       ),
       ...this.viewer.inventory.bipodLashings.filter(
+        (lashing) =>
+          lashing.pole1 === this.activeScaffold.mainPole ||
+          lashing.pole2 === this.activeScaffold.mainPole
+      ),
+      ...this.viewer.inventory.scaffoldLashings.filter(
         (lashing) =>
           lashing.pole1 === this.activeScaffold.mainPole ||
           lashing.pole2 === this.activeScaffold.mainPole
@@ -197,8 +203,10 @@ export class PoleTransformer extends THREE.Object3D {
       if (!lashing.visible) {
         if (lashing instanceof Lashing) {
           this.viewer.inventory.removeLashings([lashing]);
-        } else {
+        } else if (lashing instanceof BipodLashing) {
           this.viewer.inventory.removeBipodLashings([lashing]);
+        } else {
+          this.viewer.inventory.removeScaffoldLashings([lashing]);
         }
       } else {
         (this.viewer.scene as any).dispatchEvent({
@@ -219,6 +227,9 @@ export class PoleTransformer extends THREE.Object3D {
     } else {
       const polesToAdd = this.activeScaffold.getVisibleExtenstionPoles();
       this.viewer.inventory.addPoles(polesToAdd);
+      this.viewer.inventory.addScaffoldLashings(
+        this.activeScaffold.scaffoldLashings
+      );
     }
   }
 }

--- a/src/tools/polypedestraTool.ts
+++ b/src/tools/polypedestraTool.ts
@@ -94,12 +94,17 @@ export class PolypedestraTool extends Tool {
       if (this.polypedestraIsColliding) return;
 
       const polesToAdd = [];
+      const scaffoldLashingsToAdd = [];
       for (let i = 0; i < this.nrOfPoles; i++) {
         polesToAdd.push(...this.scaffolds[i].getVisiblePoles());
+        scaffoldLashingsToAdd.push(
+          ...this.scaffolds[i].getVisibleScaffoldLashings()
+        );
         this.scaffolds[i] = new Scaffold();
         this.scaffolds[i].addToScene(this.viewer.scene);
       }
       this.viewer.inventory.addPoles(polesToAdd);
+      this.viewer.inventory.addScaffoldLashings(scaffoldLashingsToAdd);
       this.resetParameters();
       this.setNrOfPoles(this.defaultNrOfPoles);
     }

--- a/src/tools/tripodTool.ts
+++ b/src/tools/tripodTool.ts
@@ -94,6 +94,12 @@ export class TripodTool extends Tool {
         ...this.scaffold3.getVisiblePoles(),
       ];
       this.viewer.inventory.addPoles(polesToAdd);
+      const scaffoldLashingsToAdd = [
+        ...this.scaffold1.getVisibleScaffoldLashings(),
+        ...this.scaffold2.getVisibleScaffoldLashings(),
+        ...this.scaffold3.getVisibleScaffoldLashings(),
+      ];
+      this.viewer.inventory.addScaffoldLashings(scaffoldLashingsToAdd);
       this.scaffold1 = new Scaffold();
       this.scaffold2 = new Scaffold();
       this.scaffold3 = new Scaffold();


### PR DESCRIPTION
Added the third type of lashing to the render: Scaffold lashings (Steigersjorringen).

The lashings are automatically created when a scaffold is created. They are placed 15 cm from the ends of the poles. For the moment it is not possible to move them, or place them without also creating a scaffold (similar to bipodlashings). It is, however, possible to delete them with the hatchet. Also, they will be automatically deleted when a pole is moved away from the lashing, or when one of the poles is deleted (in line with other types of lashings).