### PR TITLE
Bugfix: keystrokes being logged in console

### DIFF
--- a/src/inputHandler.ts
+++ b/src/inputHandler.ts
@@ -69,7 +69,6 @@ export class InputHandler {
         }
         break;
       default:
-        console.log("down", event.key);
         break;
     }
   }
@@ -80,7 +79,7 @@ export class InputHandler {
         this.ctrlDown = false;
         break;
       default:
-        console.log("up", event.key);
+        break;
     }
   }
 


### PR DESCRIPTION
# Keystrokes being logged in console
When pressing a button in the project that was not assigned to a function, the button was been logged to the console. This happened twice for each button (pressed down, and released)
## What changed
- Updated ```inputHandler.ts```: removed the ```console.log()``` functions from the switch default case.