### PR TITLE
Prepared drawing tools to handle custom polesets

### DIFF
--- a/src/inventory.ts
+++ b/src/inventory.ts
@@ -1,10 +1,11 @@
 import { BipodLashing } from "./objects/lashings/bipodLashing";
 import { SquareLashing } from "./objects/lashings/squareLashing";
 import { ScaffoldLashing } from "./objects/lashings/scaffoldLashing";
-import { Pole, colors, allowedLengths } from "./objects/pole";
+import { Pole } from "./objects/pole";
 import { Viewer } from "./viewer";
 import * as THREE from "three";
 import { TripodLashing } from "./objects/lashings/tripodLashing";
+import { PoleSetManager } from "./poleSet";
 
 interface IPolesDetail {
   length: number;
@@ -239,8 +240,11 @@ export class Inventory {
   }
 
   getPolesGroupedByLength() {
+    const poleSet = PoleSetManager.getInstance();
     const poles: Pole[] = this.poles;
     const polesGroupedByLength: IPolesDetail[] = [];
+    const allowedLengths = poleSet.getAllowedPoleLengths();
+    const colors = poleSet.getPoleColors();
 
     for (length of allowedLengths) {
       const number = poles.reduce((acc, pole) => {

--- a/src/objects/pole.ts
+++ b/src/objects/pole.ts
@@ -1,19 +1,6 @@
 import * as THREE from "three";
 import { v4 as uuidv4 } from "uuid";
-
-export const allowedLengths: number[] = [
-  1.0, 1.5, 2.0, 2.5, 3.0, 4.0, 5.0, 6.0,
-];
-export const colors: THREE.Color[] = [
-  new THREE.Color(0xffa500),
-  new THREE.Color(0x00ff00),
-  new THREE.Color(0xff0000),
-  new THREE.Color(0x037c6e),
-  new THREE.Color(0xffffff),
-  new THREE.Color(0x0000ff),
-  new THREE.Color(0xffff00),
-  new THREE.Color(0x000000),
-];
+import { PoleSetManager } from "../poleSet";
 
 const textureLoader = new THREE.TextureLoader();
 const colorTexture = textureLoader.load("/textures/wood/v1/wood_basecolor.jpg");
@@ -115,9 +102,12 @@ export class Pole extends THREE.Object3D {
   }
 
   setLength(minimumLength: number) {
+    const poleSet = PoleSetManager.getInstance();
+    const allowedLengths = poleSet.getAllowedPoleLengths();
+    const colors = poleSet.getPoleColors();
     // if the lenth is too big, just set it to the biggest length
-    this.length = allowedLengths[allowedLengths.length - 1];
-    this.color = colors[colors.length - 1];
+    this.length = allowedLengths.at(-1);
+    this.color = colors.at(-1);
 
     for (let i = 0; i < allowedLengths.length; i++) {
       const length = allowedLengths[i];

--- a/src/objects/scaffold.ts
+++ b/src/objects/scaffold.ts
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 import { Pole } from "../objects/pole";
 import { ScaffoldLashing } from "./lashings/scaffoldLashing";
+import { PoleSetManager } from "../poleSet";
 
 export class Scaffold {
   mainPole: Pole;
@@ -92,12 +93,10 @@ export class Scaffold {
   }
 
   setLength(minimumLength: number) {
-    let newLength = 12.0;
-    const allowedLengths: number[] = [
-      1.0, 1.5, 2.0, 2.5, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0,
-      12.0 /*16.0, 20.0, 24.0,
-      28.0, 32.0, 36.0, 40.0,*/,
-    ];
+    const poleSet = PoleSetManager.getInstance();
+    const allowedLengths = poleSet.getAllowedScaffoldLengths();
+    const maxSinglePoleLength = poleSet.getAllowedPoleLengths().at(-1);
+    let newLength = allowedLengths.at(-1);
     for (const length of allowedLengths) {
       if (length >= minimumLength) {
         newLength = length;
@@ -108,14 +107,10 @@ export class Scaffold {
 
     this.length = newLength;
 
-    if (this.length <= 6.0) {
+    if (this.length <= maxSinglePoleLength) {
       this.changeLengthToSinglePole();
-    } else if (this.length === 8.0) {
-      this.changeLengthTo8();
-    } else if (this.length === 10.0) {
-      this.changeLengthTo10();
     } else {
-      this.changeLengthTo12();
+      this.changeLengthToDoublePole();
     }
     this.mainRadius = this.mainPole.radius;
   }
@@ -129,34 +124,10 @@ export class Scaffold {
     }
   }
 
-  changeLengthTo8() {
-    this.mainPole.setLength(4.0);
-    this.extensionPole.setLength(4.0);
-    this.splintPole.setLength(4.0);
-    this.extensionPole.visible = true;
-    this.splintPole.visible = true;
-    for (const lashing of this.scaffoldLashings) {
-      lashing.visible = true;
-    }
-    this.setScaffoldLashingPositions();
-  }
-
-  changeLengthTo10() {
-    this.mainPole.setLength(5.0);
-    this.extensionPole.setLength(5.0);
-    this.splintPole.setLength(4.0);
-    this.extensionPole.visible = true;
-    this.splintPole.visible = true;
-    for (const lashing of this.scaffoldLashings) {
-      lashing.visible = true;
-    }
-    this.setScaffoldLashingPositions();
-  }
-
-  changeLengthTo12() {
-    this.mainPole.setLength(6.0);
-    this.extensionPole.setLength(6.0);
-    this.splintPole.setLength(4.0);
+  changeLengthToDoublePole() {
+    this.mainPole.setLength(this.length / 2);
+    this.extensionPole.setLength(this.length / 2);
+    this.splintPole.setLength(this.length / 3);
     this.extensionPole.visible = true;
     this.splintPole.visible = true;
     for (const lashing of this.scaffoldLashings) {

--- a/src/poleSet.ts
+++ b/src/poleSet.ts
@@ -1,0 +1,75 @@
+import { Color } from "three";
+
+type PoleSet = { length: number; color: number }[];
+
+const defaultPoleSet = [
+  { length: 1.0, color: 0xffa500 },
+  { length: 1.5, color: 0x00ff00 },
+  { length: 2.0, color: 0xff0000 },
+  { length: 2.5, color: 0x037c6e },
+  { length: 3.0, color: 0xffffff },
+  { length: 4.0, color: 0x0000ff },
+  { length: 5.0, color: 0xffff00 },
+  { length: 6.0, color: 0x000000 },
+];
+
+export class PoleSetManager {
+  private static instance: PoleSetManager;
+  private poleSet: PoleSet;
+  private allowedPoleLengths: number[];
+  private allowedScaffoldLengths: number[];
+  private colors: Color[];
+
+  private constructor() {
+    this.poleSet = defaultPoleSet;
+    this.allowedPoleLengths = this.calculateAllowedPoleLengths();
+    this.allowedScaffoldLengths = this.calculateAllowedScaffoldLengths();
+    this.colors = this.calculateColors();
+  }
+
+  public static getInstance(): PoleSetManager {
+    if (!PoleSetManager.instance) {
+      PoleSetManager.instance = new PoleSetManager();
+    }
+    return PoleSetManager.instance;
+  }
+
+  private calculateAllowedPoleLengths() {
+    return this.poleSet.map((p) => p.length);
+  }
+
+  private calculateAllowedScaffoldLengths() {
+    const singlePoleLengths = this.calculateAllowedPoleLengths();
+    const scaffoldLengths = this.poleSet
+      .map((p) => p.length * 2)
+      .filter((l) => l > singlePoleLengths.at(-1) + Number.EPSILON);
+    return [...singlePoleLengths, ...scaffoldLengths];
+  }
+
+  private calculateColors() {
+    return this.poleSet.map((p) => new Color(p.color));
+  }
+
+  public getPoleSet(): PoleSet {
+    return this.poleSet;
+  }
+
+  public setPoleSet(newPoleSet: PoleSet): void {
+    this.poleSet = newPoleSet.sort((a, b) => a.length - b.length);
+    this.allowedPoleLengths = this.calculateAllowedPoleLengths();
+    this.allowedScaffoldLengths = this.calculateAllowedScaffoldLengths();
+    this.colors = this.calculateColors();
+  }
+
+  public getAllowedPoleLengths() {
+    return this.allowedPoleLengths;
+  }
+
+  public getAllowedScaffoldLengths() {
+    return this.allowedScaffoldLengths;
+  }
+
+  public getPoleColors() {
+    return this.colors;
+  }
+}


### PR DESCRIPTION
I prepared the codebase to handle custom polesets. Everything should now work regardless of which pole lengths are allowed. You can test this by changing the hardcoded 'defaultPoleSet' in poleSet.ts. 

Integration with the frontend is to be discussed.